### PR TITLE
Refactor forum post update to use DTO with PostId

### DIFF
--- a/Backend/HealthBeside/HealthBeside.API/Controllers/ForumPostController.cs
+++ b/Backend/HealthBeside/HealthBeside.API/Controllers/ForumPostController.cs
@@ -33,17 +33,17 @@ namespace HealthBeside.API.Controllers
             return  Ok(await _forumPostService.GetByIdAsync(id));
         }
 
-        [HttpPut("update-post/{id}")]
-        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateForumPostDto dto)
+        [HttpPut("update-post")]
+        public async Task<IActionResult> Update([FromBody] UpdateForumPostDto request)
         {
             var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             if (userIdClaim is null || !Guid.TryParse(userIdClaim, out var userId))
                 return Unauthorized("Invalid or missing user identifier.");
 
-            var result = await _forumPostService.UpdateAsync(id, dto);
+            var result = await _forumPostService.UpdateAsync(request);
 
             if (!result)
-                return NotFound($"Post with id {id} not found.");
+                return NotFound($"Post not found.");
 
             return NoContent();
         }

--- a/Backend/HealthBeside/HealthBeside.Application/Contracts/Forum/ForumPostDto/UpdateForumPostDto.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Contracts/Forum/ForumPostDto/UpdateForumPostDto.cs
@@ -2,6 +2,7 @@
 
 public class UpdateForumPostDto
 {
-    public string Title { get; set; } 
-    public string Content { get; set; } 
+    public Guid PostId { get; init; }
+    public string Title { get; init; } 
+    public string Content { get; init; } 
 }

--- a/Backend/HealthBeside/HealthBeside.Application/Interfaces/IForumPostService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Interfaces/IForumPostService.cs
@@ -7,7 +7,7 @@ public interface IForumPostService
     Task<IEnumerable<GetForumPostDto>> GetAllAsync();
     Task<GetDetailedForumPostDto> GetByIdAsync(Guid id);
     Task<GetDetailedForumPostDto> CreateAsync(CreateForumPostDto forumPostDto, Guid authorId);
-    Task<bool> UpdateAsync(Guid id, UpdateForumPostDto updateForumPostDto);
+    Task<bool> UpdateAsync(UpdateForumPostDto updateForumPostDto);
     Task<bool> DeleteAsync(Guid id);
     Task<bool> Exists(Guid id);
 }

--- a/Backend/HealthBeside/HealthBeside.Application/Services/ForumPostService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Services/ForumPostService.cs
@@ -56,9 +56,9 @@ public class ForumPostService : IForumPostService
         return postWithAuthor.ToGetDetailedForumPostDto();
     }
 
-    public async Task<bool> UpdateAsync(Guid id, UpdateForumPostDto dto)
+    public async Task<bool> UpdateAsync(UpdateForumPostDto dto)
     {
-        var post = await _forumPostRepository.GetAsync(id);
+        var post = await _forumPostRepository.GetAsync(dto.PostId);
 
         if (post is null)
             return false;


### PR DESCRIPTION
Updated the forum post update flow to accept an UpdateForumPostDto containing the PostId instead of passing the post ID separately. Adjusted controller, service interface, and service implementation accordingly for improved consistency and encapsulation.