### PR TITLE
Refactor forum post update to return updated DTO

### DIFF
--- a/Backend/HealthBeside/HealthBeside.API/Controllers/ForumPostController.cs
+++ b/Backend/HealthBeside/HealthBeside.API/Controllers/ForumPostController.cs
@@ -41,10 +41,10 @@ namespace HealthBeside.API.Controllers
             {
                 var result = await _forumPostService.UpdateAsync(request, userId);
 
-                if (!result)
+                if (result is null)
                     return NotFound("Post not found.");
 
-                return NoContent();
+                return Ok(result);
             }
             catch (UnauthorizedAccessException)
             {
@@ -68,7 +68,7 @@ namespace HealthBeside.API.Controllers
             return CreatedAtAction(nameof(GetForumPost), new { id = createdPost.Id }, createdPost);
         }
 
-        [HttpDelete("delete-post}")]
+        [HttpDelete("delete-post")]
         public async Task<IActionResult> DeleteForumPost(Guid id)
         {
             var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/Backend/HealthBeside/HealthBeside.Application/Contracts/Forum/ForumPostDto/GetUpdatedForumPostDto.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Contracts/Forum/ForumPostDto/GetUpdatedForumPostDto.cs
@@ -1,0 +1,15 @@
+﻿using System.Text.Json.Serialization;
+using HealthBeside.Infrastructure;
+
+namespace HealthBeside.Application.Contracts.Forum.ForumPostDto;
+
+public class GetUpdatedForumPostDto
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } 
+    public string Content { get; set; } 
+    [JsonConverter(typeof(DateTimeLocalJsonConverter))]
+    public DateTime UpdatedAt { get; set; }
+    public int Likes { get; set; }
+    public int Dislikes { get; set; }
+}

--- a/Backend/HealthBeside/HealthBeside.Application/Extensions/Mapping/Forum/ForumPostDto/ForumPostExtension.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Extensions/Mapping/Forum/ForumPostDto/ForumPostExtension.cs
@@ -19,6 +19,19 @@ public static class ForumPostExtension
             Likes = post.Likes
         };
     }
+    
+    public static GetUpdatedForumPostDto ToGetUpdatedForumPostDto(this ForumPost post)
+    {
+        return new GetUpdatedForumPostDto
+        {
+            Id = post.Id,
+            Content = post.Content,
+            Title = post.Title,
+            UpdatedAt = post.UpdatedAt,
+            Dislikes = post.Dislikes,
+            Likes = post.Likes
+        };
+    }
 
     public static GetDetailedForumPostDto ToGetDetailedForumPostDto(this ForumPost post)
     {

--- a/Backend/HealthBeside/HealthBeside.Application/Interfaces/IForumPostService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Interfaces/IForumPostService.cs
@@ -7,7 +7,7 @@ public interface IForumPostService
     Task<IEnumerable<GetForumPostDto>> GetAllAsync();
     Task<GetDetailedForumPostDto> GetByIdAsync(Guid id);
     Task<GetDetailedForumPostDto> CreateAsync(CreateForumPostDto forumPostDto, Guid authorId);
-    Task<bool> UpdateAsync(UpdateForumPostDto updateForumPostDto, Guid userId);
+    Task<GetUpdatedForumPostDto> UpdateAsync(UpdateForumPostDto updateForumPostDto, Guid userId);
     Task<bool> DeleteAsync(Guid id, Guid userId);
     Task<bool> Exists(Guid id);
     

--- a/Backend/HealthBeside/HealthBeside.Application/Services/ForumPostService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Services/ForumPostService.cs
@@ -56,12 +56,12 @@ public class ForumPostService : IForumPostService
         return postWithAuthor.ToGetDetailedForumPostDto();
     }
 
-    public async Task<bool> UpdateAsync(UpdateForumPostDto dto, Guid userId)
+    public async Task<GetUpdatedForumPostDto> UpdateAsync(UpdateForumPostDto dto, Guid userId)
     {
         var post = await _forumPostRepository.GetAsync(dto.PostId);
 
         if (post is null)
-            return false;
+            throw new KeyNotFoundException("Forum post not found.");
         
         if(post.AuthorId != userId)
             throw new UnauthorizedAccessException("You are not authorized to update this post.");
@@ -71,9 +71,11 @@ public class ForumPostService : IForumPostService
         if (error is not null)
             throw new ArgumentException(error);
         
+        post.Touch();
+        
         await _forumPostRepository.UpdateAsync(post);
 
-        return true;
+        return post.ToGetUpdatedForumPostDto();
     }
 
     public async Task<bool> DeleteAsync(Guid id, Guid userId)

--- a/Backend/HealthBeside/HealthBeside.Domain/Models/Forum/ForumPost.cs
+++ b/Backend/HealthBeside/HealthBeside.Domain/Models/Forum/ForumPost.cs
@@ -51,25 +51,33 @@ public class ForumPost
         return (null, forumPost);
     }
     
-    public string? Update(string title, string content)
+    public string? Update(string? title, string? content)
     {
+        bool hasChanges = false;
         var errors = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(title))
-            errors.Add("Title cannot be empty.");
+        if (!string.IsNullOrWhiteSpace(title) && title != Title)
+        {
+            Title = title;
+            hasChanges = true;
+        }
 
-        if (string.IsNullOrWhiteSpace(content))
-            errors.Add("Content cannot be empty.");
+        if (!string.IsNullOrWhiteSpace(content) && content != Content)
+        {
+            Content = content;
+            hasChanges = true;
+        }
 
-        if (errors.Any())
-            return string.Join("; ", errors);
+        if (!hasChanges)
+            return "No valid changes provided.";
 
-        Title = title;
-        Content = content;
         UpdatedAt = DateTime.UtcNow;
-
         return null;
     }
-
+    
+    public void Touch()
+    {
+        UpdatedAt = DateTime.UtcNow;
+    }
 
 }

--- a/Backend/HealthBeside/HealthBeside.Infrastructure/Configurations/ForumConfiguration/ForumPostConfiguration.cs
+++ b/Backend/HealthBeside/HealthBeside.Infrastructure/Configurations/ForumConfiguration/ForumPostConfiguration.cs
@@ -15,10 +15,9 @@ public class ForumPostConfiguration : IEntityTypeConfiguration<ForumPost>
         
         builder.Property(p => p.CreatedAt)
             .HasDefaultValueSql("NOW()");
-        
+
         builder.Property(p => p.UpdatedAt)
-            .HasDefaultValueSql("NOW()")
-            .ValueGeneratedOnAddOrUpdate(); // Automatically updates the timestamp on modification
+            .HasDefaultValueSql("NOW()");
         
         builder.Property(p => p.Likes)
             .HasDefaultValue(0);


### PR DESCRIPTION
Changed the forum post update flow to return a GetUpdatedForumPostDto instead of a boolean, improving API feedback and consistency. Added new DTO, mapping extension, and updated service, interface, and controller logic. Improved validation and update logic in ForumPost model, and fixed a typo in the delete endpoint route.