### PR TITLE
Refactor MarketOrder to use new Enums namespace and add cancellation …

### DIFF
--- a/Backend/HealthBeside/HealthBeside.API/Controllers/MarketOrderController.cs
+++ b/Backend/HealthBeside/HealthBeside.API/Controllers/MarketOrderController.cs
@@ -22,16 +22,16 @@ public class MarketOrderController : ControllerBase
 
     [HttpGet("get-order/{orderId}")]
     [Authorize]
-    public async Task<ActionResult<GetOrderDto>> GetOrder(Guid orderId)
+    public async Task<ActionResult<GetOrderDto>> GetOrder(Guid orderId, CancellationToken cancellationToken = default)
     {
-        var order = await _marketOrderService.GetOrder(orderId);
+        var order = await _marketOrderService.GetOrder(orderId, cancellationToken); 
         
         return Ok(order);
     }
 
     [HttpGet("get-user-orders")]
     [Authorize]
-    public async Task<ActionResult<IEnumerable<GetOrderDto>>> GetUserOrders()
+    public async Task<ActionResult<IEnumerable<GetOrderDto>>> GetUserOrders(CancellationToken cancellationToken = default)
     {
         var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         if (userIdClaim is null || !Guid.TryParse(userIdClaim, out var userId))
@@ -39,7 +39,7 @@ public class MarketOrderController : ControllerBase
             return Unauthorized();
         }
 
-        var orders = await _marketOrderService.GetAllUserOrders(userId);
+        var orders = await _marketOrderService.GetAllUserOrders(userId, cancellationToken);
         
         return Ok(orders);
     }
@@ -49,14 +49,15 @@ public class MarketOrderController : ControllerBase
     public async Task<ActionResult<IEnumerable<GetOrderDto>>> GetAllOrders(
         [FromQuery] MarketOrderFilter marketOrderFilter,
         [FromQuery] SortParams sortParams,
-        [FromQuery] PageParams pageParams)
+        [FromQuery] PageParams pageParams,
+        CancellationToken cancellationToken = default)
     {
-        return Ok(await _marketOrderService.GetAllOrders(marketOrderFilter, sortParams, pageParams));
+        return Ok(await _marketOrderService.GetAllOrders(marketOrderFilter, sortParams, pageParams, cancellationToken));
     }
 
     [HttpPost("add-order")]
     [Authorize]
-    public async Task<ActionResult<GetOrderDto>> CreateOrder([FromBody] CreateOrderRequest request)
+    public async Task<ActionResult<GetOrderDto>> CreateOrder([FromBody] CreateOrderRequest request, CancellationToken cancellationToken = default)
     {
         var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         if (userIdClaim is null || !Guid.TryParse(userIdClaim, out var userId))
@@ -71,18 +72,19 @@ public class MarketOrderController : ControllerBase
 
     [HttpPut("update-order/{orderId}")]
     [Authorize(Roles = "Admin")]
-    public async Task<ActionResult<GetOrderDto>> UpdateOrder([FromBody] UpdateOrderRequest request, Guid orderId)
+    public async Task<ActionResult<GetOrderDto>> UpdateOrder([FromBody] UpdateOrderRequest request, Guid orderId,
+        CancellationToken cancellationToken = default)
     {
-        var updated = await _marketOrderService.UpdateOrder(orderId, request.OrderStatus);
+        var updated = await _marketOrderService.UpdateOrder(orderId, request.OrderStatus, cancellationToken);
         
         return Ok(updated);
     }
 
     [HttpDelete("delete-order/{orderId}")]
     [Authorize(Roles = "Admin")]
-    public async Task<ActionResult> DeleteOrder(Guid orderId)
+    public async Task<ActionResult> DeleteOrder(Guid orderId, CancellationToken cancellationToken = default)
     {
-        var deleted = await _marketOrderService.DeleteOrder(orderId);
+        var deleted = await _marketOrderService.DeleteOrder(orderId, cancellationToken);
         
         if (!deleted) 
             return Forbid("Order with status delivered cannot be deleted");

--- a/Backend/HealthBeside/HealthBeside.API/Program.cs
+++ b/Backend/HealthBeside/HealthBeside.API/Program.cs
@@ -136,7 +136,7 @@ public class Program
             app.MapOpenApi();
             app.MapScalarApiReference(options =>
             {
-                options.WithTitle("JWT Authentication API");
+                options.WithTitle("HealthBeside API");
             });
             app.MapGet("/", context =>
             {

--- a/Backend/HealthBeside/HealthBeside.Application/Contracts/MarketPlace/MarketOrderDto/GetOrderDto.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Contracts/MarketPlace/MarketOrderDto/GetOrderDto.cs
@@ -1,7 +1,4 @@
 ﻿using HealthBeside.Application.Contracts.MarketPlace.MarketOrderItemDto;
-using HealthBeside.Domain.Models.Enums;
-using HealthBeside.Domain.Models.Marketplace;
-using HealthBeside.Domain.Models.Users;
 
 namespace HealthBeside.Application.Contracts.MarketPlace.MarketOrderDto;
 

--- a/Backend/HealthBeside/HealthBeside.Application/Contracts/MarketPlace/MarketOrderDto/UpdateOrderRequest.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Contracts/MarketPlace/MarketOrderDto/UpdateOrderRequest.cs
@@ -1,4 +1,4 @@
-﻿using HealthBeside.Domain.Models.Enums;
+﻿using HealthBeside.Domain.Enums;
 
 namespace HealthBeside.Application.Contracts.MarketPlace.MarketOrderDto;
 

--- a/Backend/HealthBeside/HealthBeside.Application/Extensions/Mapping/Marketplace/MarketOrderDto/Order/MarketOrderExtension.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Extensions/Mapping/Marketplace/MarketOrderDto/Order/MarketOrderExtension.cs
@@ -21,8 +21,8 @@ public static class MarketOrderExtension
             OrderDate = marketOrder.OrderDate,
             TotalPrice = marketOrder.TotalPrice,
             Status = marketOrder.Status.ToString(),
-            ShippingAddress = marketOrder.ShippingAddress,
             User = marketOrder.User.ToGetUserDto(),
+            //TODO Add user address
         };
     }
 

--- a/Backend/HealthBeside/HealthBeside.Application/Interfaces/IMarketOrderService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Interfaces/IMarketOrderService.cs
@@ -2,18 +2,20 @@
 using HealthBeside.Application.Filters;
 using HealthBeside.Application.Pagination;
 using HealthBeside.Application.Sorting;
-using HealthBeside.Domain.Models.Enums;
+using HealthBeside.Domain.Enums;
 
 namespace HealthBeside.Application.Interfaces;
 
 public interface IMarketOrderService
 {
-    Task<GetOrderDto> GetOrder(Guid orderId);
-    Task<IEnumerable<GetOrderDto>> GetAllOrders(MarketOrderFilter marketOrderFilter,
+    Task<GetOrderDto> GetOrder(Guid orderId, CancellationToken cancellationToken);
+    Task<IEnumerable<GetOrderDto>> GetAllOrders(
+        MarketOrderFilter marketOrderFilter,
         SortParams sortParams,
-        PageParams pageParams);
-    Task<IEnumerable<GetOrderDto>> GetAllUserOrders(Guid userId);
-    Task<GetOrderDto> CreateOrder(Guid userId, string shippingAddress);
-    Task<GetOrderDto> UpdateOrder(Guid orderId, OrderStatus status);
-    Task<bool> DeleteOrder(Guid orderId);
+        PageParams pageParams,
+        CancellationToken cancellationToken = default);
+    Task<IEnumerable<GetOrderDto>> GetAllUserOrders(Guid userId, CancellationToken cancellationToken = default);
+    Task<GetOrderDto> CreateOrder(Guid userId, string shippingAddress, CancellationToken cancellationToken = default);
+    Task<GetOrderDto> UpdateOrder(Guid orderId, OrderStatus status, CancellationToken cancellationToken = default);
+    Task<bool> DeleteOrder(Guid orderId, CancellationToken cancellationToken = default);
 }

--- a/Backend/HealthBeside/HealthBeside.Application/Query/Filters/MarketOrderFilter.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Query/Filters/MarketOrderFilter.cs
@@ -1,4 +1,4 @@
-﻿using HealthBeside.Domain.Models.Enums;
+﻿using HealthBeside.Domain.Enums;
 
 namespace HealthBeside.Application.Filters;
 

--- a/Backend/HealthBeside/HealthBeside.Application/Services/MarketOrderService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Services/MarketOrderService.cs
@@ -1,15 +1,13 @@
 ﻿using HealthBeside.Application.Contracts.MarketPlace.MarketOrderDto;
 using HealthBeside.Application.Extensions.Mapping.Marketplace.MarketOrderDto.Order;
-using HealthBeside.Application.Extensions.Mapping.Marketplace.MarketOrderDto.OrderItem;
 using HealthBeside.Application.Filters;
 using HealthBeside.Application.Interfaces;
 using HealthBeside.Application.Pagination;
 using HealthBeside.Application.Sorting;
 using HealthBeside.Domain.Exceptions;
 using HealthBeside.Domain.Interfaces;
-using HealthBeside.Domain.Models.Enums;
+using HealthBeside.Domain.Enums;
 using HealthBeside.Domain.Models.Marketplace;
-using HealthBeside.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 namespace HealthBeside.Application.Services;
@@ -26,8 +24,7 @@ public class MarketOrderService : IMarketOrderService
         IMarketOrderItemRepository marketOrderItemRepository,
         IMarketCartItemRepository marketCartItemRepository,
         IMarketCartRepository marketCartRepository,
-        IMarketProductRepository marketProductRepository
-        )
+        IMarketProductRepository marketProductRepository)
     {
         _marketOrderRepository = marketOrderRepository;
         _marketOrderItemRepository = marketOrderItemRepository;
@@ -36,19 +33,21 @@ public class MarketOrderService : IMarketOrderService
         _marketProductRepository = marketProductRepository;
     }
 
-    public async Task<GetOrderDto> GetOrder(Guid orderId)
+    public async Task<GetOrderDto> GetOrder(Guid orderId, CancellationToken cancellationToken = default)
     {
-        var order = await _marketOrderRepository.GetOrderWithItems(orderId);
+        var order = await _marketOrderRepository.GetOrderWithItems(orderId, cancellationToken);
 
         if (order is null)
             throw new MarketOrderException($"Market order with id {orderId} not found");
 
         return order.ToGetOrderDto();
     }
+    
 
     public async Task<IEnumerable<GetOrderDto>> GetAllOrders(MarketOrderFilter? marketOrderFilter,
         SortParams? sortParams,
-        PageParams? pageParams)
+        PageParams? pageParams,
+        CancellationToken cancellationToken = default)
     {
         var query = _marketOrderRepository.GetQueryable();
 
@@ -61,23 +60,23 @@ public class MarketOrderService : IMarketOrderService
         if (pageParams != null)
             query = query.Page(pageParams);
 
-        var orders = await query.ToListAsync();
+        var orders = await query.ToListAsync(cancellationToken);
 
         return orders.Select(o => o.ToGetOrderDto());
     }
 
-    public async Task<IEnumerable<GetOrderDto>> GetAllUserOrders(Guid userId)
+    public async Task<IEnumerable<GetOrderDto>> GetAllUserOrders(Guid userId, CancellationToken cancellationToken = default)
     {
-        var orders = await _marketOrderRepository.GetAllUserOrders(userId);
+        var orders = await _marketOrderRepository.GetAllUserOrders(userId, cancellationToken);
 
         return orders.Select(o => o.ToGetOrderDto()).ToList();
     }
 
     // TODO : Додати до цього метода unitofwork 
     // TODO : Додавання перевірки наявності товару та зміни його при створенні замовлення
-    public async Task<GetOrderDto> CreateOrder(Guid userId, string shippingAddress)
+    public async Task<GetOrderDto> CreateOrder(Guid userId, string shippingAddress, CancellationToken cancellationToken = default)
     {
-        var cart = await _marketCartRepository.GetByUserId(userId);
+        var cart = await _marketCartRepository.GetByUserId(userId, cancellationToken);
 
         if (cart is null)
             throw new MarketOrderException($"Cart for user with id {userId} not found");
@@ -99,11 +98,15 @@ public class MarketOrderService : IMarketOrderService
                 throw new MarketOrderException($"The amount of desired product is less than the quantity in stock");
         }
         
-        await _marketOrderRepository.AddAsync(order);
+        await _marketOrderRepository.AddAsync(order, cancellationToken);
         
         foreach (var cartItem in cartItems)
         {
-            (error, MarketOrderItem? orderItem) = MarketOrderItem.Create(cartItem.Quantity, cartItem.MarketProduct.Price, cartItem.ProductId, order.Id);
+            (error, MarketOrderItem? orderItem) = MarketOrderItem.Create(
+                cartItem.Quantity, 
+                cartItem.MarketProduct.Price, 
+                cartItem.ProductId, 
+                order.Id);
 
             if (error is not null)
                 throw new MarketOrderException(error);
@@ -112,22 +115,23 @@ public class MarketOrderService : IMarketOrderService
                 throw new MarketOrderException($"Unknow exception while creating marker order item");
 
             cartItem.MarketProduct.UpdateStock(cartItem.MarketProduct.Quantity - cartItem.Quantity);
-            await _marketProductRepository.UpdateAsync(cartItem.MarketProduct);
-            await _marketOrderItemRepository.AddAsync(orderItem);
-            await _marketCartItemRepository.DeleteAsync(cartItem.Id);
+            await _marketProductRepository.UpdateAsync(cartItem.MarketProduct, cancellationToken);
+            await _marketOrderItemRepository.AddAsync(orderItem, cancellationToken);
+            await _marketCartItemRepository.DeleteAsync(cartItem.Id, cancellationToken);
         }
 
-        order = await _marketOrderRepository.GetOrderWithItems(order.Id);
+        order = await _marketOrderRepository.GetOrderWithItems(order.Id, cancellationToken);
 
         if (order is null)
             throw new MarketOrderException($"After creating, order was not found");
 
         return order.ToGetOrderDto();
+        
     }
 
-    public async Task<GetOrderDto> UpdateOrder(Guid orderId, OrderStatus status)
+    public async Task<GetOrderDto> UpdateOrder(Guid orderId, OrderStatus status, CancellationToken cancellationToken = default)
     {
-        var order = await _marketOrderRepository.GetOrderWithItems(orderId);
+        var order = await _marketOrderRepository.GetOrderWithItems(orderId, cancellationToken);
 
         if (order is null)
             throw new MarketOrderException($"Order with id {orderId} not found");
@@ -141,9 +145,9 @@ public class MarketOrderService : IMarketOrderService
     }
 
     // TODO : Додати Unit Of Work
-    public async Task<bool> DeleteOrder(Guid orderId)
+    public async Task<bool> DeleteOrder(Guid orderId, CancellationToken cancellationToken = default)
     {
-        var order = await _marketOrderRepository.GetOrderWithItems(orderId);
+        var order = await _marketOrderRepository.GetOrderWithItems(orderId, cancellationToken);
 
         if (order is null)
             throw new MarketOrderException($"Order with id {orderId} not found");
@@ -157,11 +161,11 @@ public class MarketOrderService : IMarketOrderService
         {
             orderItem.MarketProduct.UpdateStock(orderItem.Quantity + orderItem.MarketProduct.Quantity);
 
-            await _marketProductRepository.UpdateAsync(orderItem.MarketProduct);
-            await _marketOrderItemRepository.DeleteAsync(orderItem.Id);
+            await _marketProductRepository.UpdateAsync(orderItem.MarketProduct, cancellationToken);
+            await _marketOrderItemRepository.DeleteAsync(orderItem.Id, cancellationToken);
         }
 
-        await _marketOrderRepository.DeleteAsync(orderId);
+        await _marketOrderRepository.DeleteAsync(orderId, cancellationToken);
         return true;
     }
 }

--- a/Backend/HealthBeside/HealthBeside.Domain/Enums/OrderStatus.cs
+++ b/Backend/HealthBeside/HealthBeside.Domain/Enums/OrderStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace HealthBeside.Domain.Models.Enums;
+﻿namespace HealthBeside.Domain.Enums;
 
 public enum OrderStatus
 { 

--- a/Backend/HealthBeside/HealthBeside.Domain/Enums/PaymentStatus.cs
+++ b/Backend/HealthBeside/HealthBeside.Domain/Enums/PaymentStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace HealthBeside.Domain.Models.Enums;
+﻿namespace HealthBeside.Domain.Enums;
 
 public enum PaymentStatus
 {

--- a/Backend/HealthBeside/HealthBeside.Domain/Interfaces/IMarketOrderRepository.cs
+++ b/Backend/HealthBeside/HealthBeside.Domain/Interfaces/IMarketOrderRepository.cs
@@ -6,6 +6,6 @@ namespace HealthBeside.Domain.Interfaces;
 public interface IMarketOrderRepository : IGenericRepository<MarketOrder>
 {
     IQueryable<MarketOrder> GetQueryable();
-    Task<MarketOrder?> GetOrderWithItems(Guid id);
-    Task<IEnumerable<MarketOrder>> GetAllUserOrders(Guid userId);
+    Task<MarketOrder?> GetOrderWithItems(Guid id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<MarketOrder>> GetAllUserOrders(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/Backend/HealthBeside/HealthBeside.Domain/Models/Forum/ForumPost.cs
+++ b/Backend/HealthBeside/HealthBeside.Domain/Models/Forum/ForumPost.cs
@@ -16,8 +16,6 @@ public class ForumPost
     public ApplicationUser Author { get; private set; }
     
     public ICollection<ForumComment> Comments { get; private set; }
-    // private readonly List<ForumComment> _comments = new List<ForumComment>();
-    // public IReadOnlyCollection<ForumComment> Comments => _comments.AsReadOnly();
     
     private ForumPost() {}
     

--- a/Backend/HealthBeside/HealthBeside.Domain/Models/Marketplace/MarketOrder.cs
+++ b/Backend/HealthBeside/HealthBeside.Domain/Models/Marketplace/MarketOrder.cs
@@ -1,4 +1,4 @@
-﻿using HealthBeside.Domain.Models.Enums;
+﻿using HealthBeside.Domain.Enums;
 using HealthBeside.Domain.Models.Users;
 
 namespace HealthBeside.Domain.Models.Marketplace;
@@ -9,6 +9,8 @@ public class MarketOrder
     public DateTime OrderDate { get; private set; }
     public decimal TotalPrice { get; private set; }
     public OrderStatus Status { get; private set; }
+    
+    //TODO Add user address
     public string ShippingAddress { get; private set; }
     
     public Guid UserId { get; private set; }

--- a/Backend/HealthBeside/HealthBeside.Domain/Models/Users/ApplicationUser.cs
+++ b/Backend/HealthBeside/HealthBeside.Domain/Models/Users/ApplicationUser.cs
@@ -15,13 +15,17 @@ public class ApplicationUser : IdentityUser<Guid>
     public DoctorProfile DoctorProfile { get; set; }
     public PatientProfile PatientProfile { get; set; }
 
-    //Зробити ще навігаційні властивості форуму, замовлення, коментарів на форумі і наче все 
+    // Forum
     public ICollection<ForumPost> ForumPosts { get; private set; }
     public ICollection<ForumComment> ForumComments { get; private set; }
+
+    // Marketplace
     public ICollection<MarketReview> MarketReviews { get; private set; }
     public MarketCart? MarketCart { get; private set; }
     public ICollection<MarketOrder> MarketOrders { get; private set; }
-    public ICollection<RefreshToken> RefreshToken { get; private set; }
+
+    // Auth
+    public ICollection<RefreshToken> RefreshTokens { get; private set; }
     public DateTime? RefreshTokenExpiresAtUtc { get; private set; }
 
     public ApplicationUser() { }

--- a/Backend/HealthBeside/HealthBeside.Infrastructure/Configurations/MarketConfiguration/MarketOrderConfiguration.cs
+++ b/Backend/HealthBeside/HealthBeside.Infrastructure/Configurations/MarketConfiguration/MarketOrderConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using HealthBeside.Domain.Models.Enums;
+﻿using HealthBeside.Domain.Enums;
 using HealthBeside.Domain.Models.Marketplace;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -18,5 +18,13 @@ public class MarketOrderConfiguration : IEntityTypeConfiguration<MarketOrder>
             .HasConversion(
                 v => v.ToString(),
                 v => (OrderStatus)Enum.Parse(typeof(OrderStatus), v));
+        
+        builder.Property(o => o.OrderDate)
+            .IsRequired();
+
+        builder.Property(o => o.Status)
+            .IsRequired();
+        
+        //TODO Add user address configuration
     }
 }

--- a/Backend/HealthBeside/HealthBeside.Infrastructure/Configurations/UserConfiguration/RefreshTokenConfiguration.cs
+++ b/Backend/HealthBeside/HealthBeside.Infrastructure/Configurations/UserConfiguration/RefreshTokenConfiguration.cs
@@ -9,7 +9,7 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
     public void Configure(EntityTypeBuilder<RefreshToken> builder)
     {
         builder.HasOne(t => t.User)
-            .WithMany(u => u.RefreshToken)
+            .WithMany(u => u.RefreshTokens)
             .HasForeignKey(t => t.UserId);
     }
 }

--- a/Backend/HealthBeside/HealthBeside.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/Backend/HealthBeside/HealthBeside.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -917,7 +917,7 @@ namespace HealthBeside.Infrastructure.Migrations
                     b.Navigation("PatientProfile")
                         .IsRequired();
 
-                    b.Navigation("RefreshToken");
+                    b.Navigation("RefreshTokens");
                 });
 #pragma warning restore 612, 618
         }

--- a/Backend/HealthBeside/HealthBeside.Infrastructure/Repositories/ApplicationUserRepository.cs
+++ b/Backend/HealthBeside/HealthBeside.Infrastructure/Repositories/ApplicationUserRepository.cs
@@ -26,5 +26,6 @@ public class ApplicationUserRepository : GenericRepository<ApplicationUser>, IAp
         return user;
     }
     
+    
     //TODO: Implement other methods as needed
 }

--- a/Backend/HealthBeside/HealthBeside.Infrastructure/Repositories/MarketOrderRepository.cs
+++ b/Backend/HealthBeside/HealthBeside.Infrastructure/Repositories/MarketOrderRepository.cs
@@ -21,16 +21,16 @@ public class MarketOrderRepository : GenericRepository<MarketOrder>, IMarketOrde
             .Include(o => o.User);
     }
 
-    public async Task<MarketOrder?> GetOrderWithItems(Guid id)
+    public async Task<MarketOrder?> GetOrderWithItems(Guid id, CancellationToken cancellationToken = default)
     {
         return await _context.MarketOrders
             .Include(o => o.MarketOrderItems)
             .ThenInclude(oi => oi.MarketProduct)
             .Include(o => o.User)
-            .FirstOrDefaultAsync(o => o.Id == id);
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
     }
 
-    public async Task<IEnumerable<MarketOrder>> GetAllUserOrders(Guid userId)
+    public async Task<IEnumerable<MarketOrder>> GetAllUserOrders(Guid userId, CancellationToken cancellationToken = default)
     {
         return await _context.MarketOrders
             .Include(o => o.MarketOrderItems)
@@ -38,6 +38,7 @@ public class MarketOrderRepository : GenericRepository<MarketOrder>, IMarketOrde
             .Include(o => o.User)
             .Where(o => o.UserId == userId)
             .OrderByDescending(o => o.OrderDate)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
     }
+    
 }


### PR DESCRIPTION
…support

Moved OrderStatus and PaymentStatus enums to HealthBeside.Domain.Enums and updated all references. Added CancellationToken support to MarketOrder service, controller, and repository methods for improved async operation handling. Renamed ApplicationUser.RefreshToken to RefreshTokens and updated related configuration and navigation properties. Minor code cleanups and TODO comments for future address handling.