### PR TITLE
Add account deletion endpoint and service logic

### DIFF
--- a/Backend/HealthBeside/HealthBeside.API/Controllers/AccountController.cs
+++ b/Backend/HealthBeside/HealthBeside.API/Controllers/AccountController.cs
@@ -117,4 +117,30 @@ public class AccountController : ControllerBase
         return Ok(userInfo);
     }
 
+    [HttpDelete("delete-account")]
+    [Authorize]
+    public async Task<IActionResult> DeleteAccountAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await _accountService.DeleteAccountAsync(userId, User, cancellationToken);
+            if (result)
+                return NoContent();
+
+            return BadRequest("Account deletion failed.");
+        }
+        catch (UnauthorizedAccessException e)
+        {
+            return Forbid(e.Message); 
+        }
+        catch (AccountDeletionException e)
+        {
+            return BadRequest(e.Message);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(500, new { error = "Internal server error", details = e.Message });
+        }
+    }
+
 }

--- a/Backend/HealthBeside/HealthBeside.Application/Interfaces/IAccountService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Interfaces/IAccountService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Security.Claims;
 using HealthBeside.Application.Contracts;
+using HealthBeside.Application.Contracts.User;
 using HealthBeside.Domain.Models.Users;
 using Microsoft.AspNetCore.Identity.Data;
 using LoginRequest = HealthBeside.Application.Contracts.LoginRequest;
@@ -15,11 +16,14 @@ public interface IAccountService
         CancellationToken cancellationToken = default);
     Task RegisterAsync(RegisterRequest request);
     Task AssignRoleAsync(Guid adminUserId, Guid targetUserId, Guid newRoleId);
+    List<RoleDto> GetAvailableRoles();
     Task LoginAsync(LoginRequest request);
     Task LoginWithGoogleAsync(ClaimsPrincipal? claimsPrincipal,
         CancellationToken cancellationToken = default);
     Task RefreshTokenAsync(string? refreshToken,
         CancellationToken cancellationToken = default);
     Task LogoutAsync(string refreshToken,
+        CancellationToken cancellationToken = default);
+    Task<bool> DeleteAccountAsync(Guid userId, ClaimsPrincipal currentUser,
         CancellationToken cancellationToken = default);
 }

--- a/Backend/HealthBeside/HealthBeside.Application/Services/AccountService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Services/AccountService.cs
@@ -205,19 +205,32 @@ public class AccountService : IAccountService
     {
         var adminUser = await _userManager.FindByIdAsync(adminUserId.ToString());
         
-        if (adminUser == null || !await _userManager.IsInRoleAsync(adminUser, UserRoles.Admin)) ;
-        throw new UnauthorizedAccessException("You are not authorized to assign roles.");
+        if (adminUser == null || !await _userManager.IsInRoleAsync(adminUser, UserRoles.Admin))
+            throw new UnauthorizedAccessException("You are not authorized to assign roles.");
         
-      //  if(!UserRoles.RoleMapping.ContainsKey(newRoleId))
-        //    throw new ArgumentException("Invalid role ID provided.");
+        if(!UserRoles.RoleMapping.ContainsKey(newRoleId))
+            throw new ArgumentException("Invalid role ID provided.");
         
         var targetUser = await _userManager.FindByIdAsync(targetUserId.ToString());
+        
+        if(targetUser == null)
+            throw new KeyNotFoundException($"User with ID {targetUserId} not found.");
+        
+        var newRoleName = UserRoles.RoleMapping[newRoleId];
+        
+        var currentRoles = await _userManager.GetRolesAsync(targetUser);
+        await _userManager.RemoveFromRolesAsync(targetUser, currentRoles);
+
+        await _userManager.AddToRoleAsync(targetUser, newRoleName);
+        
+        _logger.LogInformation("Admin {AdminId} assigned role {Role} to user {UserId}", 
+            adminUserId, newRoleName, targetUserId);
     }
     
     public List<RoleDto> GetAvailableRoles()
     {
         return UserRoles.RoleMapping
-            .Where(r => r.Key != UserRoles.AdminRoleId) // Виключаємо Admin з публічного списку
+            .Where(r => r.Key != UserRoles.AdminRoleId) 
             .Select(r => new RoleDto 
             { 
                 Id = r.Key, 
@@ -318,6 +331,12 @@ public class AccountService : IAccountService
             if (!result.Succeeded)
                 throw new ExternalLoginProviderException("Google",
                     $"Unable to create user: {string.Join(", ", result.Errors.Select(e => e.Description))}");
+            
+            var roleResult = await _userManager.AddToRoleAsync(newUser, UserRoles.User);
+            
+            if (!roleResult.Succeeded)
+                throw new ExternalLoginProviderException("Google",
+                    $"Unable to assign role: {string.Join(", ", roleResult.Errors.Select(e => e.Description))}");
 
             user = newUser;
         }
@@ -418,8 +437,38 @@ public class AccountService : IAccountService
         _authTokenProcessor.WriteAuthTokenToHttpOnlyCookie("ACCESS_TOKEN", jwtToken, expiresAt);
         _authTokenProcessor.WriteAuthTokenToHttpOnlyCookie("REFRESH_TOKEN", newRefreshTokenString, newRefreshTokenExpirationTokenTimeAtUtc);
     }
+
+    public async Task<bool> DeleteAccountAsync(Guid userId, ClaimsPrincipal currentUser, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.FindByIdAsync(userId.ToString());
+        
+        if(user == null)
+            throw new AccountDeletionException("User not found.");
+        
+        var currentUserId = currentUser.FindFirstValue(ClaimTypes.NameIdentifier);
+        
+        if(currentUserId == null)
+            throw new AccountDeletionException("Unable to delete account. Current user not found.");
+        
+        var isAdmin = currentUser.IsInRole(UserRoles.Admin);
+        
+        var isOwner = user.Id.ToString() == currentUserId;
+
+        if (!isAdmin && !isOwner)
+        {
+            throw new UnauthorizedAccessException("You are not authorized to delete this account.");
+        }
+        
+        var result = await _userManager.DeleteAsync(user);
+        if(!result.Succeeded)
+        {
+            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+            throw new AccountDeletionException($"Failed to delete account: {errors}");
+        }
+        _logger.LogInformation("User {UserId} account deleted successfully", userId);
+        return true;
+    }
 }
 
-//TODO fix roles in DB
 //TODO обіграти логіку, аби якщо користувач зареєструвався як юзер, то при записі на консультацію,
 //він повинен заповнити всі поля профілю пацієнта, а якщо як лікар, то всі поля профілю лікаря

--- a/Backend/HealthBeside/HealthBeside.Application/Services/StripeService.cs
+++ b/Backend/HealthBeside/HealthBeside.Application/Services/StripeService.cs
@@ -59,7 +59,7 @@ public class StripeService : IStripeService
         
         var user = await _userRepository.GetAsync(order.UserId);
 
-        if (order.Status == OrderStatus.Canceled)
+        if (order.Status == OrderStatus.Cancelled)
             throw new StripeException($"Cannot create checkout session, order with id {order.Id} is canceled");
         
         var options = new SessionCreateOptions
@@ -163,7 +163,7 @@ public class StripeService : IStripeService
                             break;
                         }
 
-                        if (order.Status == OrderStatus.Canceled)
+                        if (order.Status == OrderStatus.Cancelled)
                         {
                             _logger.LogWarning("User paid for already canceled order {OrderId}", orderId);
 
@@ -229,7 +229,7 @@ public class StripeService : IStripeService
 
                 case EventTypes.PaymentIntentCanceled:
                 {
-                    if (payment.Status == PaymentStatus.Canceled && order.Status == OrderStatus.Canceled)
+                    if (payment.Status == PaymentStatus.Cancelled && order.Status == OrderStatus.Cancelled)
                     {
                         _logger.LogInformation("Payment and Order already canceled");
                         break;
@@ -238,13 +238,13 @@ public class StripeService : IStripeService
                     await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
                     try
                     {
-                        payment.UpdateStatus(PaymentStatus.Canceled);
+                        payment.UpdateStatus(PaymentStatus.Cancelled);
 
                         var error = payment.ApplyStripeCancelled(paymentIntent.Id);
                         if (error != null)
                             throw new StripeException($"Error while applying payment intent info to payment : {error}");
 
-                        order.UpdateStatus(OrderStatus.Canceled);
+                        order.UpdateStatus(OrderStatus.Cancelled);
 
                         await _marketOrderRepository.UpdateAsync(order, cancellationToken);
                         await _paymentRepository.UpdateAsync(payment, cancellationToken);
@@ -267,13 +267,13 @@ public class StripeService : IStripeService
                         break;
                     }
                     
-                    if (order.Status == OrderStatus.Canceled)
+                    if (order.Status == OrderStatus.Cancelled)
                     {
                         _logger.LogInformation("Order {OrderId} already canceled by background service, ignoring payment failure", orderId);
                         return;
                     }
 
-                    if (payment.Status == PaymentStatus.Canceled)
+                    if (payment.Status == PaymentStatus.Cancelled)
                     {
                         _logger.LogInformation("Payment already canceled");
                         break;

--- a/Backend/HealthBeside/HealthBeside.Domain/Exceptions/AccountDeletionException.cs
+++ b/Backend/HealthBeside/HealthBeside.Domain/Exceptions/AccountDeletionException.cs
@@ -1,0 +1,3 @@
+﻿namespace HealthBeside.Domain.Exceptions;
+
+public class AccountDeletionException(string message) : Exception($"Error while deleting account: {message}");


### PR DESCRIPTION
Introduces an API endpoint for account deletion in AccountController, adds DeleteAccountAsync to IAccountService and its implementation, and creates AccountDeletionException for error handling. Also fixes role assignment logic and updates StripeService to use 'Cancelled' status consistently.